### PR TITLE
Combined experiment performance improvements

### DIFF
--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -144,11 +144,13 @@ module Split
     end
 
     def has_winner?
-      !winner.nil?
+      return @has_winner if defined? @has_winner
+      @has_winner = !winner.nil?
     end
 
     def winner=(winner_name)
       redis.hset(:experiment_winner, name, winner_name.to_s)
+      @has_winner = true
     end
 
     def participant_count
@@ -161,6 +163,7 @@ module Split
 
     def reset_winner
       redis.hdel(:experiment_winner, name)
+      @has_winner = false
     end
 
     def start

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -81,11 +81,11 @@ module Split
 
       if new_record?
         start unless Split.configuration.start_manually
+        persist_experiment_configuration
       elsif experiment_configuration_has_changed?
         reset unless Split.configuration.reset_manually
+        persist_experiment_configuration
       end
-
-      persist_experiment_configuration if new_record? || experiment_configuration_has_changed?
 
       redis.hset(experiment_config_key, :resettable, resettable)
       redis.hset(experiment_config_key, :algorithm, algorithm.to_s)

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -8,9 +8,11 @@ module Split
 
     def initialize(context, adapter=nil)
       @user = adapter || Split::Persistence.adapter.new(context)
+      @cleaned_up = false
     end
 
     def cleanup_old_experiments!
+      return if @cleaned_up
       keys_without_finished(user.keys).each do |key|
         experiment = ExperimentCatalog.find key_without_version(key)
         if experiment.nil? || experiment.has_winner? || experiment.start_time.nil?
@@ -18,6 +20,7 @@ module Split
           user.delete Experiment.finished_key(key)
         end
       end
+      @cleaned_up = true
     end
 
     def max_experiments_reached?(experiment_key)

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -142,7 +142,7 @@ describe Split::Dashboard do
     it "removes winner" do
       post "/reopen?experiment=#{experiment.name}"
 
-      expect(experiment).to_not have_winner
+      expect(Split::ExperimentCatalog.find(experiment.name)).to_not have_winner
     end
 
     it "keeps existing stats" do

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -213,11 +213,40 @@ describe Split::Experiment do
     it "should have no winner initially" do
       expect(experiment.winner).to be_nil
     end
+  end
 
+  describe 'winner=' do
     it "should allow you to specify a winner" do
       experiment.save
       experiment.winner = 'red'
       expect(experiment.winner.name).to eq('red')
+    end
+
+    context 'when has_winner state is memoized' do
+      before { expect(experiment).to_not have_winner }
+
+      it 'should keep has_winner state consistent' do
+        experiment.winner = 'red'
+        expect(experiment).to have_winner
+      end
+    end
+  end
+
+  describe 'reset_winner' do
+    before { experiment.winner = 'green' }
+
+    it 'should reset the winner' do
+      experiment.reset_winner
+      expect(experiment.winner).to be_nil
+    end
+
+    context 'when has_winner state is memoized' do
+      before { expect(experiment).to have_winner }
+
+      it 'should keep has_winner state consistent' do
+        experiment.reset_winner
+        expect(experiment).to_not have_winner
+      end
     end
   end
 
@@ -234,6 +263,12 @@ describe Split::Experiment do
       it 'returns false' do
         expect(experiment).to_not have_winner
       end
+    end
+
+    it 'memoizes has_winner state' do
+      expect(experiment).to receive(:winner).once
+      expect(experiment).to_not have_winner
+      expect(experiment).to_not have_winner
     end
   end
 

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -59,6 +59,17 @@ describe Split::User do
         expect(@subject.keys).to include("link_color:finished")
       end
     end
+
+    context 'when already cleaned up' do
+      before do
+        @subject.cleanup_old_experiments!
+      end
+
+      it 'does not clean up again' do
+        expect(@subject).to_not receive(:keys_without_finished)
+        @subject.cleanup_old_experiments!
+      end
+    end
   end
 
   context "instantiated with custom adapter" do


### PR DESCRIPTION
Reduce the number of redundant Redis operations executed for the same request. This way the performance of a test with combined experiments is expected to improve.

- Cache `Experiment#has_winner?` result for the lifetime of an experiment instance 
- Remove redundant calls to Redis in `Experiment#save`
- Cleanup Split user old experiments only once during the lifetime of a User instance
- Specs added

--
Resolves issue [#573](https://github.com/splitrb/split/issues/573)