### PR TITLE
Handle correctly case when ab_finished is called before ab_test for a user

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -44,6 +44,7 @@ module Split
     end
 
     def finish_experiment(experiment, options = {:reset => true})
+      return false if active_experiments[experiment.name].nil?
       return true if experiment.has_winner?
       should_reset = experiment.resettable? && options[:reset]
       if ab_user[experiment.finished_key] && !should_reset


### PR DESCRIPTION
When an experiment e.g. `:my_experiment` already exists in Redis and then for a user we have the following flow:
1. `ab_finished(:my_experiment, reset: false)`
2. `ab_test(:my_experiment)`
3. `ab_finished(:my_experiment, reset: false)`

then the `completed` counter is not increased as expected the second time `ab_finished` is called.

This happens because the first time `ab_finished` is called with `reset: false` option, it will change the `ab_user` state, setting the experiment's `finished_key` to `true` [here](https://github.com/splitrb/split/blob/84beb9e3e08b42020f2b96c22bf7615cb79320d6/lib/split/helper.rb#L60). This way, when `ab_finished` is called again, it will return before the `completed` counter is increased due to this [check](https://github.com/splitrb/split/blob/84beb9e3e08b42020f2b96c22bf7615cb79320d6/lib/split/helper.rb#L49).